### PR TITLE
Retrieve server name from env var - Iss11

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,10 @@ Windows:
 * npm install
 * npm install nodemon
 * npm start
+
+
+DEPLOY
+-------------------
+* The server is looking for the environment variable MULT_WEB_SEQ_SERV. If Undefined, it is set to localhost.
+
+> export MULT_WEB_SEQ_SERV=myserver:8080

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ var http = require('http').Server(app);
 var io = require('socket.io')(http);
 var bodyParser = require('body-parser');
 var eventEmitter = require('events').EventEmitter
+var hostname = '127.0.0.1:8080';
 var stateJson = {
   pads: {
     'kick': new Map(),
@@ -118,7 +119,14 @@ io.sockets.on('connection', function (socket) {
 });
 
 app.get('/', (req, res) => {
-  res.render('index.ejs');
+  console.log(process.env.MULT_WEB_SEQ_SERV);
+  if (typeof process.env.MULT_WEB_SEQ_SERV != 'undefined')
+  {      
+      hostname=process.env.MULT_WEB_SEQ_SERV;
+  }
+  console.log('server is:', hostname);
+
+  res.render('index.ejs', {hostname:hostname});
 
 })
 

--- a/server.js
+++ b/server.js
@@ -120,14 +120,11 @@ io.sockets.on('connection', function (socket) {
 
 app.get('/', (req, res) => {
   console.log(process.env.MULT_WEB_SEQ_SERV);
-  if (typeof process.env.MULT_WEB_SEQ_SERV != 'undefined')
-  {      
-      hostname=process.env.MULT_WEB_SEQ_SERV;
+  if (typeof process.env.MULT_WEB_SEQ_SERV != 'undefined') {      
+    hostname=process.env.MULT_WEB_SEQ_SERV;
   }
   console.log('server is:', hostname);
-
   res.render('index.ejs', {hostname:hostname});
-
 })
 
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -101,7 +101,9 @@
     }
 
     $(function() {
-      socket = io.connect('http://localhost:8080');
+      var servername='<%= hostname %>';
+      console.log("connecting to ", servername);
+      socket = io.connect(servername);
 
       // on recieve sequencer state
       socket.on('SendCurrentState', function(json) {


### PR DESCRIPTION
This commit is aiming at solving #11. A environment variable MULT_WEB_SEQ_SERV can be set to indicate the server name. It is then given as an argument to the view template and used for websocket connection in clients.