### PR TITLE
Export audio output as opus - Iss 27

### DIFF
--- a/static/javascripts/app.js
+++ b/static/javascripts/app.js
@@ -244,7 +244,6 @@ function init() {
   loadImpulseResponses();
 }
 
-
 function initializeAudioNodes() {
   context = new webkitAudioContext();
   recordingDest = context.createMediaStreamDestination();

--- a/static/javascripts/app.js
+++ b/static/javascripts/app.js
@@ -164,11 +164,12 @@ function RecordListener() {
 }
 
 function OnDataAvailableInRecorderFunc(evt) {
-    // push each chunk (blobs) in an array
-    chunks.push(evt.data);
-    console.log(evt.data);
+  // push each chunk (blobs) in an array
+  if(evt.data.size>0){
+    chunks.push(evt.data);    
     var blob = new Blob(chunks, { 'type' : 'audio/ogg; codecs=opus' });
     document.querySelector("audio").src = URL.createObjectURL(blob);
+  }
 };
 
 

--- a/static/javascripts/app.js
+++ b/static/javascripts/app.js
@@ -163,6 +163,14 @@ function RecordListener() {
   });
 }
 
+function OnDataAvailableInRecorderFunc(evt) {
+    // push each chunk (blobs) in an array
+    chunks.push(evt.data);
+    console.log(evt.data);
+    var blob = new Blob(chunks, { 'type' : 'audio/ogg; codecs=opus' });
+    document.querySelector("audio").src = URL.createObjectURL(blob);
+};
+
 
 function TranslateStateInActions(sequencerState) {
   var trackNames = sequencerState['trackNames'];
@@ -239,14 +247,7 @@ function initializeAudioNodes() {
   recordingDest = context.createMediaStreamDestination();
   mediaRecorder = new MediaRecorder(recordingDest.stream);
 
-  mediaRecorder.ondataavailable = function(evt) {
-    console.log("Pushing Data");
-    // push each chunk (blobs) in an array
-    chunks.push(evt.data);
-    console.log(evt.data);
-    var blob = new Blob(chunks, { 'type' : 'audio/ogg; codecs=opus' });
-    document.querySelector("audio").src = URL.createObjectURL(blob);
-  };
+  mediaRecorder.ondataavailable = OnDataAvailableInRecorderFunc;
   
   var finalMixNode;
   if (context.createDynamicsCompressor && COMPRESSOR_ACTIVATED) {

--- a/static/javascripts/app.js
+++ b/static/javascripts/app.js
@@ -649,7 +649,7 @@ function deleteTrack(trackId) {
   currentKit.waves.splice(trackId, 1);
 
   // delete gain
-  currentKit.gains.splice(trackId, 1);
+  currentKit.gainNodes.splice(trackId, 1);
 }
 
 

--- a/static/javascripts/app.js
+++ b/static/javascripts/app.js
@@ -168,7 +168,10 @@ function OnDataAvailableInRecorderFunc(evt) {
   if(evt.data.size>0){
     chunks.push(evt.data);    
     var blob = new Blob(chunks, { 'type' : 'audio/ogg; codecs=opus' });
-    document.querySelector("audio").src = URL.createObjectURL(blob);
+    var soundSrc = URL.createObjectURL(blob);
+    var NewHtmlEl = '<audio src=' + soundSrc+' controls=controls></audio><br>';
+    $(NewHtmlEl).appendTo(".exported-audio");
+    chunks = [];
   }
 };
 

--- a/static/javascripts/app.js
+++ b/static/javascripts/app.js
@@ -114,7 +114,7 @@ function changeQuality(event, ui) {
   lowPassFilterNode.Q.value = ui.value * 30;
 }
 
-function CheckAndTrigerPlayPause() {
+function checkAndTrigerPlayPause() {
   var $span = $('#play-pause').children("span");
   if ($span.hasClass('glyphicon-play')) {
     $span.removeClass('glyphicon-play');
@@ -136,7 +136,7 @@ function CheckAndTrigerPlayPause() {
 //  }
 //})
 
-function CheckAndTrigerRecord() {
+function checkAndTrigerRecord() {
  if(!isrecording){
    console.log("Record is triggered");
    isrecording=1;
@@ -153,24 +153,24 @@ function CheckAndTrigerRecord() {
 
 function playPauseListener() {
   $('#play-pause').click(function () {
-    CheckAndTrigerPlayPause();
+    checkAndTrigerPlayPause();
   });
 }
 
 function RecordListener() {
   $('#record').click(function () {
-    CheckAndTrigerRecord();
+    checkAndTrigerRecord();
   });
 }
 
-function OnDataAvailableInRecorderFunc(evt) {
+function onDataAvailableInRecorderFunc(evt) {
   // push each chunk (blobs) in an array
   if(evt.data.size>0){
     chunks.push(evt.data);    
     var blob = new Blob(chunks, { 'type' : 'audio/ogg; codecs=opus' });
     var soundSrc = URL.createObjectURL(blob);
-    var NewHtmlEl = '<audio src=' + soundSrc+' controls=controls></audio><a href=' + soundSrc + ' download="exported_loop.ogg">Download</a><br>';
-    $(NewHtmlEl).appendTo(".exported-audio");
+    var newHtmlEl = '<audio src=' + soundSrc+' controls=controls></audio><a href=' + soundSrc + ' download="exported_loop.ogg">Download</a><br>';
+    $(newHtmlEl).appendTo(".exported-audio");
     chunks = [];
   }
 };
@@ -245,13 +245,12 @@ function init() {
 }
 
 
-
 function initializeAudioNodes() {
   context = new webkitAudioContext();
   recordingDest = context.createMediaStreamDestination();
   mediaRecorder = new MediaRecorder(recordingDest.stream);
 
-  mediaRecorder.ondataavailable = OnDataAvailableInRecorderFunc;
+  mediaRecorder.ondataavailable = onDataAvailableInRecorderFunc;
   
   var finalMixNode;
   if (context.createDynamicsCompressor && COMPRESSOR_ACTIVATED) {

--- a/static/javascripts/app.js
+++ b/static/javascripts/app.js
@@ -170,7 +170,7 @@ function onDataAvailableInRecorderFunc(evt) {
       'type': 'audio/ogg; codecs=opus'
     });
     var soundSrc = URL.createObjectURL(blob);
-    var newHtmlEl = '<div style="height:40px; margin:3px;"><audio src=' + soundSrc + ' controls=controls></audio><span style="position: absolute; margin:3px;" class="btn btn-success" href=' + soundSrc + ' download="exported_loop.ogg">Download</span><br><div>';
+    var newHtmlEl = '<div style="height:40px; margin:3px;"><audio src=' + soundSrc + ' controls=controls></audio><a style="position: absolute; margin:3px;" class="btn btn-success" href=' + soundSrc + ' download="exported_loop.ogg">Download</a><br><div>';
     $(newHtmlEl).appendTo(".exported-audio");
     chunks = [];
   }

--- a/static/javascripts/app.js
+++ b/static/javascripts/app.js
@@ -169,7 +169,7 @@ function onDataAvailableInRecorderFunc(evt) {
     chunks.push(evt.data);    
     var blob = new Blob(chunks, { 'type' : 'audio/ogg; codecs=opus' });
     var soundSrc = URL.createObjectURL(blob);
-    var newHtmlEl = '<audio src=' + soundSrc+' controls=controls></audio><a href=' + soundSrc + ' download="exported_loop.ogg">Download</a><br>';
+    var newHtmlEl = '<audio src=' + soundSrc+' controls=controls></audio><a href=' + soundSrc + ' download="exported_loop.ogg">  Download</a><br>';
     $(newHtmlEl).appendTo(".exported-audio");
     chunks = [];
   }

--- a/static/javascripts/app.js
+++ b/static/javascripts/app.js
@@ -169,7 +169,7 @@ function OnDataAvailableInRecorderFunc(evt) {
     chunks.push(evt.data);    
     var blob = new Blob(chunks, { 'type' : 'audio/ogg; codecs=opus' });
     var soundSrc = URL.createObjectURL(blob);
-    var NewHtmlEl = '<audio src=' + soundSrc+' controls=controls></audio><br>';
+    var NewHtmlEl = '<audio src=' + soundSrc+' controls=controls></audio><a href=' + soundSrc + ' download="exported_loop.ogg">Download</a><br>';
     $(NewHtmlEl).appendTo(".exported-audio");
     chunks = [];
   }

--- a/static/javascripts/app.js
+++ b/static/javascripts/app.js
@@ -12,6 +12,7 @@ var lastDrawTime = -1;
 var rhythmIndex = 0;
 var timeoutId;
 var testBuffer = null;
+var isrecording = false;
 
 var currentKit = null;
 var wave = null;
@@ -131,9 +132,26 @@ function CheckAndTrigerPlayPause() {
 //  }
 //})
 
+function CheckAndTrigerRecord() {
+   if(!isrecording){
+       console.log("Record is triggered");
+       isrecording=1;
+   }
+   else{
+       console.log("Record is untriggered");
+       isrecording=0;
+   }    
+}
+
 function playPauseListener() {
   $('#play-pause').click(function () {
     CheckAndTrigerPlayPause();
+  });
+}
+
+function RecordListener() {
+  $('#record').click(function () {
+    CheckAndTrigerRecord();
   });
 }
 
@@ -208,6 +226,9 @@ function init() {
 
 function initializeAudioNodes() {
   context = new webkitAudioContext();
+  var dest = context.createMediaStreamDestination();
+  var mediaRecorder = new MediaRecorder(dest.stream);
+  
   var finalMixNode;
   if (context.createDynamicsCompressor && COMPRESSOR_ACTIVATED) {
     // Create a dynamics compressor to sweeten the overall mix.

--- a/static/javascripts/app.js
+++ b/static/javascripts/app.js
@@ -140,11 +140,13 @@ function CheckAndTrigerRecord() {
  if(!isrecording){
    console.log("Record is triggered");
    isrecording=1;
+   $('#record').css('color','red');
    mediaRecorder.start();
  }
  else{
    console.log("Record is untriggered");
    isrecording=0;
+   $('#record').css('color','white');
    mediaRecorder.stop();
  }    
 }

--- a/static/javascripts/app.js
+++ b/static/javascripts/app.js
@@ -170,7 +170,7 @@ function onDataAvailableInRecorderFunc(evt) {
       'type': 'audio/ogg; codecs=opus'
     });
     var soundSrc = URL.createObjectURL(blob);
-    var newHtmlEl = '<audio src=' + soundSrc + ' controls=controls></audio><a href=' + soundSrc + ' download="exported_loop.ogg">  Download</a><br>';
+    var newHtmlEl = '<div style="height:40px; margin:3px;"><audio src=' + soundSrc + ' controls=controls></audio><span style="position: absolute; margin:3px;" class="btn btn-success" href=' + soundSrc + ' download="exported_loop.ogg">Download</span><br><div>';
     $(newHtmlEl).appendTo(".exported-audio");
     chunks = [];
   }

--- a/static/javascripts/app.js
+++ b/static/javascripts/app.js
@@ -6,6 +6,7 @@ var masterGainNode;
 var effectLevelNode;
 var lowPassFilterNode;
 var mediaRecorder;
+var recordingDest;
 var chunks = [];
 
 var noteTime;
@@ -233,16 +234,14 @@ function init() {
 
 function initializeAudioNodes() {
   context = new webkitAudioContext();
-  var dest = context.createMediaStreamDestination();
-  mediaRecorder = new MediaRecorder(dest.stream);
+  recordingDest = context.createMediaStreamDestination();
+  mediaRecorder = new MediaRecorder(recordingDest.stream);
 
   mediaRecorder.ondataavailable = function(evt) {
+    console.log("Pushing Data");
     // push each chunk (blobs) in an array
     chunks.push(evt.data);
-  };
-
-  mediaRecorder.onstop = function(evt) {
-    // Make blob out of our blobs, and open it.
+    console.log(evt.data);
     var blob = new Blob(chunks, { 'type' : 'audio/ogg; codecs=opus' });
     document.querySelector("audio").src = URL.createObjectURL(blob);
   };
@@ -316,6 +315,7 @@ function playNote(buffer, noteTime, startTime, endTime, gainNode) {
 
   voice.connect(gainNode)
   gainNode.connect(currentLastNode);
+  gainNode.connect(recordingDest);
   voice.start(noteTime, startTime, endTime - startTime);
 }
 

--- a/static/javascripts/app.js
+++ b/static/javascripts/app.js
@@ -137,18 +137,17 @@ function checkAndTrigerPlayPause() {
 //})
 
 function checkAndTrigerRecord() {
- if(!isrecording){
-   console.log("Record is triggered");
-   isrecording=1;
-   $('#record').css('color','red');
-   mediaRecorder.start();
- }
- else{
-   console.log("Record is untriggered");
-   isrecording=0;
-   $('#record').css('color','white');
-   mediaRecorder.stop();
- }    
+  if (!isrecording) {
+    console.log("Record is triggered");
+    isrecording = 1;
+    $('#record').css('color', 'red');
+    mediaRecorder.start();
+  } else {
+    console.log("Record is untriggered");
+    isrecording = 0;
+    $('#record').css('color', 'white');
+    mediaRecorder.stop();
+  }
 }
 
 function playPauseListener() {
@@ -165,16 +164,17 @@ function RecordListener() {
 
 function onDataAvailableInRecorderFunc(evt) {
   // push each chunk (blobs) in an array
-  if(evt.data.size>0){
-    chunks.push(evt.data);    
-    var blob = new Blob(chunks, { 'type' : 'audio/ogg; codecs=opus' });
+  if (evt.data.size > 0) {
+    chunks.push(evt.data);
+    var blob = new Blob(chunks, {
+      'type': 'audio/ogg; codecs=opus'
+    });
     var soundSrc = URL.createObjectURL(blob);
-    var newHtmlEl = '<audio src=' + soundSrc+' controls=controls></audio><a href=' + soundSrc + ' download="exported_loop.ogg">  Download</a><br>';
+    var newHtmlEl = '<audio src=' + soundSrc + ' controls=controls></audio><a href=' + soundSrc + ' download="exported_loop.ogg">  Download</a><br>';
     $(newHtmlEl).appendTo(".exported-audio");
     chunks = [];
   }
-};
-
+}
 
 function TranslateStateInActions(sequencerState) {
   var trackNames = sequencerState['trackNames'];
@@ -192,7 +192,7 @@ function TranslateStateInActions(sequencerState) {
     for (var i = numLocalTracks - 1; i >= 0; i--) {
       deleteTrack(i);
     }
-    
+
     // change tempo
     changeTempo(tempo);
 
@@ -250,7 +250,7 @@ function initializeAudioNodes() {
   mediaRecorder = new MediaRecorder(recordingDest.stream);
 
   mediaRecorder.ondataavailable = onDataAvailableInRecorderFunc;
-  
+
   var finalMixNode;
   if (context.createDynamicsCompressor && COMPRESSOR_ACTIVATED) {
     // Create a dynamics compressor to sweeten the overall mix.
@@ -396,8 +396,8 @@ function initializeTempo() {
 }
 
 function changeTempo(tempo_input) {
-    tempo = tempo_input;
-    $("#tempo-input").val(tempo_input);
+  tempo = tempo_input;
+  $("#tempo-input").val(tempo_input);
 }
 
 function changeTempoListener() {
@@ -546,11 +546,11 @@ function addKnob(trackId, gain) {
     step: 1,
     displayInput: false,
     thickness: 0.5,
-    change : function(v) {
+    change: function (v) {
       var trackId = $(this.$).parents('.instrument').index();
       currentKit.gainNodes[trackId].gain.value = linear2db(v);
     },
-    release: function(v) {
+    release: function (v) {
       var trackId = $(this.$).parents('.instrument').index();
       currentKit.gainNodes[trackId].gain.value = linear2db(v);
       // send db gain value to server
@@ -647,7 +647,7 @@ function deleteTrack(trackId) {
 
   // delete wave
   currentKit.waves.splice(trackId, 1);
-  
+
   // delete gain
   currentKit.gains.splice(trackId, 1);
 }

--- a/static/stylesheets/styles.css
+++ b/static/stylesheets/styles.css
@@ -50,7 +50,7 @@ body {
   font: black;
 }
 
-.instrument, .instruments, #search-container, .wave, .tempoBorder, .wave, #room-container, #chat-container {
+.instrument, .instruments, #search-container, .wave, .tempoBorder, .wave, #room-container, #chat-container, #export-container {
   margin-top: 7px;
   border-width: 1px;
   border-style: groove;

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -139,7 +139,7 @@
     <!--   EXPORT CONTAINER    -->
     <div class="row" id="export-container" style="padding-top: 10px; padding-bottom:10px;">
       <div class="col-md-6 chat">
-        <audio controls></audio>
+        <div class="exported-audio"></div>
       </div>
     </div>
     <br>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -138,7 +138,8 @@
     
     <!--   EXPORT CONTAINER    -->
     <div class="row" id="export-container" style="padding-top: 10px; padding-bottom:10px;">
-      <div class="col-md-6 chat">
+      <div class="col-md-6 export">
+        <label >Exported audio:</label>
         <div class="exported-audio"></div>
       </div>
     </div>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -48,6 +48,9 @@
         <button id="play-pause" type="button" class="btn btn-success">
           <span class="glyphicon glyphicon-play" aria-hidden="true"></span>
         </button>
+        <button id="record" type="button" class="btn btn-success">
+          <span class="glyphicon glyphicon-record" aria-hidden="true"></span>
+        </button>
         <span class="tempo-container">
           <label >Tempo:</label>
           <input id="tempo-input" disabled>
@@ -130,6 +133,13 @@
           <ul class="messages"></ul>
         </div>
         <input class="inputMessage" placeholder="Type here..." />
+      </div>
+    </div>
+    
+    <!--   EXPORT CONTAINER    -->
+    <div class="row" id="export-container" style="padding-top: 10px; padding-bottom:10px;">
+      <div class="col-md-6 chat">
+        <audio controls></audio>
       </div>
     </div>
     <br>


### PR DESCRIPTION
This PR is aiming to implement feature described in issue #27.

The audio output of the WebAudio graph is exported through a mediaRecorder node. If the record is trigerred through the button, all audio chunks are redirected through a Blob and then are dynamically added to the page as a downloable and playable audio file (ogg).

This can only be used as a live recorder (ie: the sequencer must be in a play state). 