### PR TITLE
Iss20 - Sampler does not work when no tab focus

### DIFF
--- a/static/javascripts/app.js
+++ b/static/javascripts/app.js
@@ -346,7 +346,7 @@ function schedule() {
     }
     advanceNote();
   }
-  timeoutId = requestAnimationFrame(schedule)
+  timeoutId = setTimeout(schedule, 50);
 }
 
 function drawPlayhead(xindex) {

--- a/static/javascripts/app.js
+++ b/static/javascripts/app.js
@@ -15,7 +15,8 @@ var lastDrawTime = -1;
 var rhythmIndex = 0;
 var timeoutId;
 var testBuffer = null;
-var isrecording = false;
+var isRecording = false;
+var isPlaying = false;
 
 var currentKit = null;
 var wave = null;
@@ -119,8 +120,10 @@ function checkAndTrigerPlayPause() {
   if ($span.hasClass('glyphicon-play')) {
     $span.removeClass('glyphicon-play');
     $span.addClass('glyphicon-pause');
+    isPlaying = 1;
     handlePlay();
   } else {
+    isPlaying = 0;
     $span.addClass('glyphicon-play');
     $span.removeClass('glyphicon-pause');
     handleStop();
@@ -139,12 +142,12 @@ function checkAndTrigerPlayPause() {
 function checkAndTrigerRecord() {
   if (!isrecording) {
     console.log("Record is triggered");
-    isrecording = 1;
+    isRecording = 1;
     $('#record').css('color', 'red');
     mediaRecorder.start();
   } else {
     console.log("Record is untriggered");
-    isrecording = 0;
+    isRecording = 0;
     $('#record').css('color', 'white');
     mediaRecorder.stop();
   }
@@ -344,9 +347,11 @@ function schedule() {
       lastDrawTime = noteTime;
       drawPlayhead(rhythmIndex);
     }
-    advanceNote();
+    if(isPlaying)
+      advanceNote();
   }
-  timeoutId = setTimeout(schedule, 50);
+  if(isPlaying)
+    timeoutId = setTimeout(schedule, 50);
 }
 
 function drawPlayhead(xindex) {

--- a/static/javascripts/app.js
+++ b/static/javascripts/app.js
@@ -140,7 +140,7 @@ function checkAndTrigerPlayPause() {
 //})
 
 function checkAndTrigerRecord() {
-  if (!isrecording) {
+  if (!isRecording) {
     console.log("Record is triggered");
     isRecording = 1;
     $('#record').css('color', 'red');

--- a/static/javascripts/app.js
+++ b/static/javascripts/app.js
@@ -392,7 +392,7 @@ function handlePlay(event) {
 }
 
 function handleStop(event) {
-  cancelAnimationFrame(timeoutId);
+  clearTimeout(timeoutId);
   $(".pad").removeClass("playing");
 }
 


### PR DESCRIPTION
This PR aims at solving issue #20 
The Catarak Web Audio Sequencer is using requestAnimationFrame to schedule the next update. Unfortunately this function is paused when the application runs in background. 
This PR replace it with the setTimeout function. This will be less precise and more CPU consuming than the requestAnimationFrame, but at least the audio renderer will still work while in background mode.